### PR TITLE
Fix a type issue and adjust image_handler ratio

### DIFF
--- a/src/RPALite/image_handler.py
+++ b/src/RPALite/image_handler.py
@@ -115,7 +115,7 @@ class ImageHandler:
 
                     results.append( (location, target_text, 1))
 
-            elif ratio > best_ratio and ratio > 0.6 and ((rect is not None and self.check_point_inide_rect(r[0][0], rect)) or rect is None) and self.check_text_and_filter_in_window(image, text_arr, r[0], r[1], filter_args_in_parent, rect):
+            elif ratio > best_ratio and ratio > 0.75 and ((rect is not None and self.check_point_inide_rect(r[0][0], rect)) or rect is None) and self.check_text_and_filter_in_window(image, text_arr, r[0], r[1], filter_args_in_parent, rect):
                 best_ratio = ratio
                 target_text = r[1]
                 position = r[0]

--- a/src/RPALite/rpalite.py
+++ b/src/RPALite/rpalite.py
@@ -497,8 +497,8 @@ class RPALite:
                 sorted_locations = sorted(locations, key=lambda x: (x[0]-title_position[0])**2 + (x[1]-title_position[1])**2)
             else:
                 sorted_locations = [locations]
-            location = sorted_locations[0]
-            self.click_by_position(int(location[0]), int(location[1]), button, double_click)
+            location = sorted_locations[0][0]
+            self.click_by_position(location[0], location[1], button, double_click)
             self.sleep()
         self.sleep()
 


### PR DESCRIPTION
1. Fix a bug that change location value from list "[(x,y,z,h)]" to a tuple (x,y,z,h).

2. Improve image_handler ratio to 0.75, to avoid return an unexpected text. 
E.g. when calling wait_until_text_exists('Rebuild completed', timeout=300), although "Rebuild completed" not exist in the screen, it will still return a location.